### PR TITLE
Remove js error for undefined variable

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -214,9 +214,15 @@ def myLinkHandler(reviewer, url, _old):
 
         # Reset timer from Speed Focus Mode add-on.
         reviewer.bottom.web.eval("""
-            clearTimeout(autoAnswerTimeout);
-            clearTimeout(autoAlertTimeout);
-            clearTimeout(autoAgainTimeout);
+            if (typeof autoAnswerTimeout !== 'undefined') {
+                clearTimeout(autoAnswerTimeout);
+            }
+            if (typeof autoAlertTimeout !== 'undefined') {
+                clearTimeout(autoAlertTimeout);
+            }
+            if (typeof autoAgainTimeout !== 'undefined') {
+                clearTimeout(autoAgainTimeout);
+            }
         """)
         
     elif url == "EFDRC!reload":


### PR DESCRIPTION
This PR ensures that there is no warning about undefined variable when Focus Mode is not installed.
Furthermore, it also ensures that the execution does not stop, so let me add more feature when editing