### PR TITLE
Add an option to edit everywhere

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from anki import version as ankiversion
 from anki.hooks import addHook, wrap
+from anki import hooks
 from anki.utils import htmlToTextLine
 from aqt import mw
 from aqt.editor import Editor
@@ -152,8 +153,16 @@ def myRevBottomHTML(reviewer, _old):
 
     return _old(reviewer) + script
 
+def edit_everywhere(field_text, node):
+    return edit(field_text, node.field_name)
 
-def edit(txt, extra, context, field, fullname):
+def edit_one(txt, extra, context, field, fullname):
+    if not config["apply everywhere"]:
+        return edit(txt, field)
+    else:
+        return txt
+
+def edit(txt, field):
     ctrl = bool_to_str(config["ctrl_click"])
 
     # Encode field to escape special characters.
@@ -277,4 +286,6 @@ def myLinkHandler(reviewer, url, _old):
 Reviewer._bottomHTML = wrap(Reviewer._bottomHTML, myRevBottomHTML, "around")
 Reviewer.revHtml = wrap(Reviewer.revHtml, myRevHtml, "around")
 Reviewer._linkHandler = wrap(Reviewer._linkHandler, myLinkHandler, "around")
-addHook('fmod_edit', edit)
+addHook('fmod_edit', edit_one)
+if config["apply everywhere"]:
+    hooks.template_filter_all_fields.append(edit_everywhere)

--- a/config.json
+++ b/config.json
@@ -1,4 +1,5 @@
 {
+  "apply everywhere": false,
   "ctrl_click":false,
   "outline": true,
   "process_paste": true,

--- a/config.md
+++ b/config.md
@@ -1,5 +1,7 @@
 ## Config Options
 
+- apply everywhere: If set to `true`, all fields are editable.
+
 - ctrl_click: If set to `true`, ctrl+click on a field to edit. Default: `false`.
 
 - outline: If set to `true`, add a blue outline around the field when it is in edit mode. Default, `true`.

--- a/config.schema.json
+++ b/config.schema.json
@@ -3,6 +3,11 @@
   "type": "object",
   "title": "Edit Field During Review Cloze",
   "properties": {
+    "apply everywhere": {
+      "type": "boolean",
+      "description": "If set to `true`, all fields are editable.",
+      "default": false
+    },
     "ctrl_click": {
       "type": "boolean",
       "title": "Ctrl click",


### PR DESCRIPTION
This won't currently work until Anki's PR
https://github.com/ankitects/anki/pull/521 is accepted.

When the option is set, it disable "edit:" since in this case "edit:" is useless.