### PR TITLE
Add support for Anki 2.1.31+

### DIFF
--- a/edit_field_during_review_cloze/reviewer.py
+++ b/edit_field_during_review_cloze/reviewer.py
@@ -132,9 +132,12 @@ def saveField(note, fld, val):
     else:
         # aqt.editor.Editor.onBridgeCmd
         txt = unicodedata.normalize("NFC", val)
-        txt = Editor.mungeHTML(None, txt)
-        txt = txt.replace("\x00", "")
-        txt = mw.col.media.escapeImages(txt, unescape=True)
+        if ankiver_major == "2.1" and ankiver_minor < 31:
+            txt = Editor.mungeHTML(None, txt)
+            txt = txt.replace("\x00", "")
+            txt = mw.col.media.escapeImages(txt, unescape=True)
+        else:
+            txt = Editor.mungeHTML(editorwv.editor, txt)
         field = note[fld]
     if field == txt:
         return


### PR DESCRIPTION
Hello,

Due to the commits ankitects/anki@4720645, ankitects/anki@f5479ed and ankitects/anki@f5479ed, an `AttributeError` is raised on Anki 2.1.31 or higher. This PR should fix the issue.

Fixes #34, Fixes #36