### PR TITLE
Remove checkpoint and flush for better 23.10+ compatibility

### DIFF
--- a/src/addon/reviewer.py
+++ b/src/addon/reviewer.py
@@ -81,8 +81,7 @@ def saveField(note: Note, fld: str, val: str) -> None:
         if note[fld] == txt:
             return
         note[fld] = txt
-    mw.checkpoint("Edit Field")
-    note.flush()
+    mw.col.update_note(note)
 
 
 def get_value(note: Note, fld: str) -> str:


### PR DESCRIPTION
This fixes #107.

Since 23.10 flush and checkpoint are deprecated, see [the forums](https://forums.ankiweb.net/t/porting-tips-for-anki-23-10/35916#save-checkpoint-and-flush-are-deprecated-3). The transition was done in 2.1.45, so this change should be backwards compatible since that version, although I have only tested it on 23.10.1.